### PR TITLE
Add reflectToAttribute to ariaLabel property

### DIFF
--- a/d2l-checkbox.html
+++ b/d2l-checkbox.html
@@ -132,7 +132,8 @@ Polymer-based web component for D2L checkboxes
 				 * an explicit label (through child elements) isn't provided.
 				 */
 				ariaLabel: {
-					type: String
+					type: String,
+					reflectToAttribute: true
 				},
 				/**
 				 * Gets or sets the [aria-labelledby attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute),


### PR DESCRIPTION
This PR asks Polymer to update the `aria-label` attribute so that the CSS rule that removes the extraneous label margin is applied without having to manually trigger it with `element.setAttribute("aria-label", "...")`.