### PR TITLE
Explicitly set d2l-checkbox "checked" property within change handler

### DIFF
--- a/d2l-checkbox.html
+++ b/d2l-checkbox.html
@@ -101,7 +101,7 @@ Polymer-based web component for D2L checkboxes
 				type="checkbox"
 				aria-label$="[[ariaLabel]]"
 				aria-labelledby$="[[ariaLabelledby]]"
-				checked="{{checked::change}}"
+				checked="{{checked}}"
 				disabled$="[[disabled]]"
 				name$="[[name]]"
 				on-change="_handleChange"
@@ -178,7 +178,9 @@ Polymer-based web component for D2L checkboxes
 			focus: function() {
 				this.$$('input').focus();
 			},
-			_handleChange: function() {
+			_handleChange: function(e) {
+				this.checked = e.target.checked;
+
 				// in shady DOM the input's "change" event will leak through,
 				// so no need to fire it
 				if (Polymer.Element || Polymer.Settings.useShadow) {

--- a/test/d2l-checkbox.html
+++ b/test/d2l-checkbox.html
@@ -129,6 +129,26 @@
 							MockInteractions.tap(input);
 						});
 
+						it('should reflect that a previously unchecked input is now checked', function(done) {
+							var input = elem.$$('input');
+							elem.addEventListener('change', function(e) {
+								expect(e.target.checked).to.equal(true);
+								done();
+							});
+							MockInteractions.tap(input);
+						});
+
+						it('should reflect that a previously checked input is now unchecked', function(done) {
+							elem = fixture('checked');
+							var input = elem.$$('input');
+
+							elem.addEventListener('change', function(e) {
+								expect(e.target.checked).to.equal(false);
+								done();
+							});
+							MockInteractions.tap(input);
+						});
+
 					});
 
 				});


### PR DESCRIPTION
It seems that the `change` event handler is called prior to the `checked` property being updated from the binding on the native input element. Consumer elements checking the `target.checked` property of the event passed to a `change` event handler (where the target will be `d2l-checkbox`) will see the old value, rather than the new one.